### PR TITLE
Add Ubuntu 22.10

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -29,6 +29,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | Canonical | Ubuntu | impish (21.10) | 1.1.1 | Not vuln | https://packages.ubuntu.com/search?keywords=openssl | |
 | Canonical | Ubuntu | focal (20.04 LTS) | 1.1.1 | Not vuln | https://packages.ubuntu.com/search?keywords=openssl | |
 | Canonical | Ubuntu | jammy (22.04 LTS) | 3.0.2 | Vulnerable | https://packages.ubuntu.com/search?keywords=openssl | |
+| Canonical | Ubuntu | kinetic (22.10) | 3.0.5 | Vulnerable | https://packages.ubuntu.com/search?keywords=openssl | |
 | CentOS | CentOS | 7.9 | 1.0.2 | Not vuln | https://isc.sans.edu/diary/Upcoming+Critical+OpenSSL+Vulnerability+What+will+be+Affected/29192/ | |
 | CentOS | CentOS | 8 | 1.1.1 | Not vuln| https://isc.sans.edu/diary/Upcoming+Critical+OpenSSL+Vulnerability+What+will+be+Affected/29192/ | |
 | CentOS | CentOS | >= 9 | 3.x | Vulnerable | https://www.redhat.com/en/blog/experience-bringing-openssl-30-rhel-and-fedora | |


### PR DESCRIPTION
Ubuntu 22.10 currently offers Openssl 3.0.5 and this can be vulnerable. Verified by locally checking out the container.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>