### PR TITLE
Add Red Hat - Universal Base Images < v9.0

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -287,6 +287,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | PHP	| PHP	| >= 8.1 | Unknown | Investigation | https://www.php.net/manual/en/openssl.requirements.php | |
 | Red Hat | Enterprise Linux | >= 9.0 | 3.x	| Vulnerable | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004	| | 
 | Red Hat | OpenShift Container Platform | => 4.0 | 1.1.1 | Not vuln | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004 | |
+| Red Hat | Universal Base Images | <= 8 | 1.1.1 | Not vuln | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004 | |
 | Red Hat | Universal Base Images | >= 9.0 | 3.x | Vulnerable | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004 | |
 | Rocky Enterprise Software Foundation | Rocky Linux | 8.0 | 1.1.1k | Not vuln | https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/Packages/o/openssl-1.1.1k-7.el8_6.x86_64.rpm| |
 | Rocky Enterprise Software Foundation | Rocky Linux | 9.0 (Blue Onyx) | 3.0.1 | Vulnerable | https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages/o/openssl-3.0.1-41.el9_0.x86_64.rpm| |


### PR DESCRIPTION
The list didn't specify the Red Hat UBI images older than 9.0. This PR fixes that.




Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - [x] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [ ] Status: please select a value from the status table at the top
  - [ ] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [ ] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [x] Please mind the sorting