### PR TITLE
Add Node.js 17 - Investigation

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -245,6 +245,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | NetBSD | NetBSD | 9 | 1.1.1k | Not vuln | https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/CHANGES-9.2 |
 | NetBSD | NetBSD | 8 | 1.0.2k | Not vuln | https://netbsd.org/releases/formal-8/NetBSD-8.0.html |
 | NetBSD | pkgsrc | - | 1.1.1q | Not vuln | https://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/security/openssl/index.html|
+| Node.js | JavaScript Runtime Environment | 17 | 3.x | Investigation | https://nodejs.org/en-us/blog/vulnerability/openssl-november-2022/ | Missing from blog post because Node.js 17 is EOL |
 | Node.js | JavaScript Runtime Environment | 18 | 3.x | Investigation | https://nodejs.org/zh-cn/blog/vulnerability/openssl-november-2022/ ||
 | Node.js | JavaScript Runtime Environment | 19 | 3.x | Investigation | https://nodejs.org/zh-cn/blog/vulnerability/openssl-november-2022/ ||
 | Offensive Security | Kali | 2022.3 | 3.0.5 | Vulnerable | https://pkg.kali.org/pkg/openssl | 

--- a/software/README.md
+++ b/software/README.md
@@ -245,7 +245,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | NetBSD | NetBSD | 9 | 1.1.1k | Not vuln | https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/CHANGES-9.2 |
 | NetBSD | NetBSD | 8 | 1.0.2k | Not vuln | https://netbsd.org/releases/formal-8/NetBSD-8.0.html |
 | NetBSD | pkgsrc | - | 1.1.1q | Not vuln | https://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/security/openssl/index.html|
-| Node.js | JavaScript Runtime Environment | 17 | 3.x | Investigation | https://nodejs.org/en-us/blog/vulnerability/openssl-november-2022/ | Missing from blog post because Node.js 17 is EOL |
+| Node.js | JavaScript Runtime Environment | 17 | 3.x | Investigation | https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#17.0.0 | Missing from Node.js security update blog post because v17 is EOL |
 | Node.js | JavaScript Runtime Environment | 18 | 3.x | Investigation | https://nodejs.org/zh-cn/blog/vulnerability/openssl-november-2022/ ||
 | Node.js | JavaScript Runtime Environment | 19 | 3.x | Investigation | https://nodejs.org/zh-cn/blog/vulnerability/openssl-november-2022/ ||
 | Offensive Security | Kali | 2022.3 | 3.0.5 | Vulnerable | https://pkg.kali.org/pkg/openssl | 


### PR DESCRIPTION
Add Node.js 17. It's missing from vendor's blog post, but a member of the Node.js security team told me it was deliberately omitted since it's EOL and won't be receiving an update. Their blog post describes their pending updates, not which versions are vulnerable.

Changelog indicates all of 17.x uses OpenSSL 3.0 https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#17.0.0

For contributions in `software/`:

  - [X] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [X] Status: please select a value from the status table at the top
  - X ] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [X] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [X] Please mind the sorting