### PR TITLE
Update Code42 status to Not vuln

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -45,7 +45,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | CentOS | CentOS | 8 | 1.1.1 | Not vuln| https://isc.sans.edu/diary/Upcoming+Critical+OpenSSL+Vulnerability+What+will+be+Affected/29192/ | |
 | CentOS | CentOS | >= 9 | 3.x | Vulnerable | https://www.redhat.com/en/blog/experience-bringing-openssl-30-rhel-and-fedora | |
 | Cisco | All | Unknown | Unknown | Investigation | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |
-| Code42 | Incydr | ALL | 1.x | Investigation | [Code42 Response to Industry Security Incidents](https://support.code42.com/Terms_and_conditions/Code42_customer_support_resources/Code42_response_to_industry_security_incidents) | |
+| Code42 | Incydr | ALL | 1.x | Not vuln | [Code42 Response to Industry Security Incidents](https://support.code42.com/Terms_and_conditions/Code42_customer_support_resources/Code42_response_to_industry_security_incidents) | |
 | Debian | Debian | 9 "Stretch"	| 1.1.0 | Not vuln | https://packages.debian.org/stretch/openssl	| |
 | Debian | Debian | 10 "Buster"	| 1.1.1	| Not vuln | https://packages.debian.org/buster/openssl | |
 | Debian | Debian | 11 "Bullseye"	| 1.1.1	| Not vuln | https://packages.debian.org/bullseye/openssl | |


### PR DESCRIPTION
With CVE disclosure, Code42 Incydr status is now Not vuln rather than Investigation. 

Current status is reflected on the [industry response page](https://support.code42.com/Terms_and_conditions/Code42_customer_support_resources/Code42_response_to_industry_security_incidents).




Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - [x] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [x] Status: please select a value from the status table at the top
  - [x] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [x] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [x] Please mind the sorting