### PR TITLE
Add Fedora/EPEL

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -167,6 +167,8 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | Fedora | Linux | 36 | 3.0.2 | Vulnerable | https://packages.fedoraproject.org/pkgs/openssl/openssl/ | |
 | Fedora | Linux | 37 | 3.0.5 | Vulnerable | https://packages.fedoraproject.org/pkgs/openssl/openssl/ | |
 | Fedora | Linux | Rawhide | 3.0.5 | Vulnerable | https://packages.fedoraproject.org/pkgs/openssl/openssl/ | |
+| Fedora | EPEL | 7 | 1.1.1k | Not vuln | https://packages.fedoraproject.org/pkgs/openssl11/openssl11/ | |
+| Fedora | EPEL | 8 | 3.0.1 | Vulnerable | https://packages.fedoraproject.org/pkgs/openssl3/openssl3/ | |
 | FileCap | FileCap Server | All | < 3.x | Not vuln | https://github.com/NCSC-NL/OpenSSL-2022/blob/main/software/vendor-statements/FileCap.png | | 
 | Fortinet | FortiADC | All | n.a. | Not vuln | https://www.fortiguard.com/psirt/FG-IR-22-419 | |
 | Fortinet | FortiADCManager | All | n.a. | Not vuln | https://www.fortiguard.com/psirt/FG-IR-22-419 | |


### PR DESCRIPTION
Packages in EPEL (or other 3rd party packages) might rely on the additionally provided OpenSSL version in EPEL.

  * EPEL 8 provides optionally OpenSSL from RHEL 9
  * EPEL 7 provides optionally OpenSSL from RHEL 8

Whether an EPEL package relies on OpenSSL from RHEL or on EPEL is up to the specific EPEL package and EPEL packager.