### PR TITLE
Mark CentOS Stream 9 as fixed

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -43,7 +43,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | Canonical | Ubuntu | Squid | 3.0.5 5 | Vulnerable | https://hub.docker.com/r/ubuntu/squid/tags | |
 | CentOS | CentOS | 7.9 | 1.0.2 | Not vuln | https://isc.sans.edu/diary/Upcoming+Critical+OpenSSL+Vulnerability+What+will+be+Affected/29192/ | |
 | CentOS | CentOS | 8 | 1.1.1 | Not vuln| https://isc.sans.edu/diary/Upcoming+Critical+OpenSSL+Vulnerability+What+will+be+Affected/29192/ | |
-| CentOS | CentOS | >= 9 | 3.x | Vulnerable | https://www.redhat.com/en/blog/experience-bringing-openssl-30-rhel-and-fedora | |
+| CentOS | CentOS | 9 | 3.0.1-43.el9 | Fix | https://gitlab.com/redhat/centos-stream/rpms/openssl/-/commit/39f800af50db23de7aa01ebd56c8132589ad36a8 | |
 | Check Point | All | All | 1.1.1 | Not vuln | https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk92447&partition=Basic&product=All | |
 | Cisco | All | Unknown | Unknown | Investigation | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |
 | Code42 | Incydr | ALL | 1.x | Not vuln | [Code42 Response to Industry Security Incidents](https://support.code42.com/Terms_and_conditions/Code42_customer_support_resources/Code42_response_to_industry_security_incidents) | |


### PR DESCRIPTION
The fix is in the current compose that's being pushed out to mirrors:

https://composes.stream.centos.org/production/CentOS-Stream-9-20221101.0/compose/BaseOS/x86_64/os/Packages/
https://composes.stream.centos.org/production/CentOS-Stream-9-20221101.0/compose/BaseOS/aarch64/os/Packages/
https://composes.stream.centos.org/production/CentOS-Stream-9-20221101.0/compose/BaseOS/ppc64le/os/Packages/
https://composes.stream.centos.org/production/CentOS-Stream-9-20221101.0/compose/BaseOS/s390x/os/Packages/

Signed-off-by: Michel Alexandre Salim <salimma@centosproject.org>




Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - [x] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [x] Status: please select a value from the status table at the top
  - [x] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [x] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [x] Please mind the sorting