### PR TITLE
Updated Red Hat Universal Base Images link

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -317,7 +317,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | Red Hat | Enterprise Linux | >= 9.0 | 3.0.1-43	| Fix | https://access.redhat.com/errata/RHSA-2022:7288	| | 
 | Red Hat | OpenShift Container Platform | => 4.0 | 1.1.1 | Not vuln | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004 | |
 | Red Hat | Universal Base Images | <= 8 | 1.x | Not vuln | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004 | |
-| Red Hat | Universal Base Images | >= 9.0 | 3.x | Vulnerable | https://access.redhat.com/security/vulnerabilities/RHSB-2022-004 | |
+| Red Hat | Universal Base Images | >= 9.0 | 3.x | Vulnerable | https://catalog.redhat.com/software/containers/ubi9/618326f8c0d15aff4912fe0b/ | |
 | Rocky Enterprise Software Foundation | Rocky Linux | 8.0 | 1.1.1k | Not vuln | https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/Packages/o/openssl-1.1.1k-7.el8_6.x86_64.rpm| |
 | Rocky Enterprise Software Foundation | Rocky Linux | 9.0 (Blue Onyx) | 3.0.1-43 | Fix | https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages/o/openssl-3.0.1-43.el9_0.x86_64.rpm| |
 | PulseSecure (Ivanti) | All | Unknown | Unknown | Not vuln | https://kb.pulsesecure.net/articles/Pulse_Secure_Article/OpenSSL-3-0-x-Vulnerability-Ivanti-Product-Impact1/?kA13Z000000FseL | |


### PR DESCRIPTION
The link previous published was not showing information about the Red Hat UBI images, the new link shows the current OpenSSL version and the date of image publication.

Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - [ x] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [x ] Status: please select a value from the status table at the top
  - [x ] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [x ] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [x ] Please mind the sorting