### PR TITLE
Remove extra backtick

### DIFF
--- a/scanning/README.md
+++ b/scanning/README.md
@@ -78,7 +78,7 @@ openssl version
 #### RHEL, Fedora, Oracle, CentOS:
 
 ```
-rpm -qa --queryformat "%{NAME} %{VERSION} %{RELEASE}\n"` | grep openssl
+rpm -qa --queryformat "%{NAME} %{VERSION} %{RELEASE}\n" | grep openssl
 ```
 
 #### Running processes running OpenSSL 3.x 


### PR DESCRIPTION
removes extra backtick so command can be copied and pasted




Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - [ ] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [ ] Status: please select a value from the status table at the top
  - [ ] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [ ] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [ ] Please mind the sorting