### PR TITLE
Add cPanel (all) - not vuln

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -79,6 +79,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | Cisco | Ultra Cloud Core - User Plane Function | Unknown | Unknown | Not vuln | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |
 | Cloudflare | all | all | Unknown | Not vuln | https://blog.cloudflare.com/cloudflare-is-not-affected-by-the-openssl-vulnerabilities-cve-2022-3602-and-cve-2022-37/ | |
 | Code42 | Incydr | ALL | 1.x | Not vuln | [Code42 Response to Industry Security Incidents](https://support.code42.com/Terms_and_conditions/Code42_customer_support_resources/Code42_response_to_industry_security_incidents) | |
+| cPanel | All | All | Unknown | Not vuln | https://support.cpanel.net/hc/en-us/articles/4416312844055-Is-cPanel-affected-by-OpenSSL-Security-Advisory-CVE-2021-4044- | |
 | Debian | Debian | 9 "Stretch"	| 1.1.0 | Not vuln | https://packages.debian.org/stretch/openssl	| |
 | Debian | Debian | 10 "Buster"	| 1.1.1	| Not vuln | https://packages.debian.org/buster/openssl | |
 | Debian | Debian | 11 "Bullseye"	| 1.1.1	| Not vuln | https://packages.debian.org/bullseye/openssl | |


### PR DESCRIPTION
Ref text:

https://support.cpanel.net/hc/en-us/articles/4416312844055-Is-cPanel-affected-by-OpenSSL-Security-Advisory-CVE-2021-4044-#:~:text=cpanel%20servers%20don't%20use%20openssl%20version%203
