### PR TITLE
Add Cisco/ClamAV

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -74,6 +74,9 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | CentOS | CentOS | 9 | 3.0.1-43 | Fix | https://gitlab.com/redhat/centos-stream/rpms/openssl/-/commit/39f800af50db23de7aa01ebd56c8132589ad36a8 | |
 | Check Point | All | All | 1.1.1 | Not vuln | https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk92447&partition=Basic&product=All | |
 | Cisco | Application Policy Infrastructure Controller (APIC) | Unknown | Unknown | Not vuln | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |
+| Cisco | ClamAV | Linux versions | Unknown | Investigation | https://blog.clamav.net/2014/02/introducing-openssl-as-dependency-to.html | |
+| Cisco | ClamAV | Mac versions | Unknown | Investigation | https://blog.clamav.net/2014/02/introducing-openssl-as-dependency-to.html | |
+| Cisco | ClamAV | Windows versions | Unknown | Investigation | https://blog.clamav.net/2014/07/compiling-openssl-for-windows.html | |
 | Cisco | Container Platform | Unknown | Unknown | Not vuln | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |
 | Cisco | Data Center Network Manager (DCNM) | Unknown | Unknown | Not vuln | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |
 | Cisco | Elastic Services Controller (ESC) | Unknown | Unknown | Not vuln | https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-W9sdCc2a | |


### PR DESCRIPTION
OpenSSL is a ClamAV dependency and the ClamAV binaries provided by Cisco on the regular ClamAV website are statically linked against a bundled OpenSSL (unknown version), at least for Linux I've been able to verify this:

```
wget https://www.clamav.net/downloads/production/clamav-0.105.1-2.linux.x86_64.rpm
rpm2cpio clamav-0.105.1-2.linux.x86_64.rpm | cpio -idm  # Extract RPM
strings usr/local/lib64/libclamav.so.9.1.0 | grep -i openssl  # OpenSSL matches
ldd usr/local/lib64/libclamav.so.9.1.0  # Not linked against libcrypto/libssl
```

I'm however unsure how to verify for Mac and Windows, but I guess these aren't built using much different options in general.

Some pointers to get it merged quickly:

For contributions in `software/`:

  - [x] PR Title: Please use "Add <vendor/product name>" (instead of "Update README.md")
  - [x] Status: please select a value from the status table at the top
  - [x] Version: Status Vulnerable / Workaround? -> List vulnerable versions.
                 Status Fix?                     -> List fixed versions.
  - [x] Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/` directory
  - [x] Please mind the sorting